### PR TITLE
Added Optional Color Parameter for .growingArc

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,11 @@ You may alter it with standard SwiftUI means like this:
 `scalingDots`  
 `opacityDots`  
 `equalizer`  
-`growingArc`  
+`growingArc` - add custom color for growing Arc, the default value is `Color.red`
+   ```swift
+   ActivityIndicatorView(isVisible: $showLoadingIndicator, type: .growingArc(.red))
+       .frame(width: 50.0, height: 50.0)
+   ```
 `growingCircle`  
 `gradient` - circle with angular gradient border stroke, pass colors ilke this:
    ```swift

--- a/Source/ActivityIndicatorView.swift
+++ b/Source/ActivityIndicatorView.swift
@@ -18,7 +18,7 @@ public struct ActivityIndicatorView: View {
         case scalingDots
         case opacityDots
         case equalizer
-        case growingArc
+        case growingArc(Color = Color.red)
         case growingCircle
         case gradient([Color])
     }
@@ -52,8 +52,8 @@ public struct ActivityIndicatorView: View {
             indicator = createOpacityDotsIndicator()
         case .equalizer:
             indicator = createEqualizerIndicator()
-        case .growingArc:
-            indicator = createGrowingArcIndicator()
+        case .growingArc(let color):
+            indicator = createGrowingArcIndicator(color: color)
         case .growingCircle:
             indicator = createGrowingCircleIndicator()
         case .gradient(let colors):
@@ -252,9 +252,9 @@ public struct ActivityIndicatorView: View {
         return AnyView(indicator)
     }
 
-    func createGrowingArcIndicator() -> AnyView {
+    func createGrowingArcIndicator(color: Color) -> AnyView {
         let indicator = GeometryReader { (geometry: GeometryProxy) in
-            GrowingArc(p: self.parameter).stroke(Color.red, lineWidth: 4)
+            GrowingArc(p: self.parameter).stroke(color, lineWidth: 4)
         }.onAppear() {
             withAnimation(Animation.easeIn(duration: 2).repeatForever(autoreverses: false)) {
                 self.parameter = 1


### PR DESCRIPTION
Problem:
By default, the stroke color of the arc is `Color.red`. Unable to override using foregroundColor.

Solution:
Add optional color parameter with the default value of `Color.red`, allowing user to customize the stroke color.