### PR TITLE
Add underscore type parameter name

### DIFF
--- a/Source/ActivityIndicatorView.swift
+++ b/Source/ActivityIndicatorView.swift
@@ -20,7 +20,7 @@ public struct ActivityIndicatorView: View {
         case equalizer(count: Int = 5)
         case growingArc(Color = .black, lineWidth: CGFloat = 4)
         case growingCircle
-        case gradient([Color], CGLineCap = .butt, lineWidth: CGFloat = 4)
+        case gradient(_ colors: [Color], CGLineCap = .butt, lineWidth: CGFloat = 4)
     }
 
     @Binding var isVisible: Bool


### PR DESCRIPTION
Hello. :)

I use **ActivityIndicatorView** well, but whenever I use a `gradient` type indicator, I feel a little uncomfortable.
So i modified the code a little.

Whenever you use the `gradient` type, Xcode's auto-completion only displays the `(lineWidth:)` format.
<img width="473" alt="pic1" src="https://user-images.githubusercontent.com/13725729/218600957-ccdd33e7-18d2-4b5c-b189-e9a1865891e8.png">


If you just press enter, the `lineWidth` parameter is automatically completed, so you have to **delete this text every time.**
And I think it might be a bit confusing for first-time users.
![pic2](https://user-images.githubusercontent.com/13725729/218601016-5eed25e9-af80-4ae7-ae89-875c8c1e40a3.png)


So, I added the name of the **underscore type** to the `[Color]` array parameter of the `gradient` enum.

Then, it will work as follows, and the user will just have to press enter once and add the desired `[Color]`.

<img width="451" alt="pic3" src="https://user-images.githubusercontent.com/13725729/218601043-4d628a3e-fcc7-4f1a-9e27-b4b18641829c.png">
<img width="309" alt="pic4" src="https://user-images.githubusercontent.com/13725729/218601054-f7b12e5b-3737-4090-91b9-205c32a01be1.png">
